### PR TITLE
Android HiddenInputField input

### DIFF
--- a/game.project
+++ b/game.project
@@ -7,3 +7,6 @@ shared_state = 1
 [display]
 width = 960
 height = 640
+
+[android]
+input_method = HiddenInputField


### PR DESCRIPTION
Set default value for Android input method to HiddenInputField as current default does not work on newer phones and it often leads to issues when set